### PR TITLE
allow passing functions to 'option.filters'

### DIFF
--- a/lib/walk.js
+++ b/lib/walk.js
@@ -220,6 +220,11 @@
     // Stop directories that contain filter keywords
     // from continuing through the walk process
     exclude = me._wfilters.some(function (filter) {
+      
+      if (typeof filter === 'function'){
+        return filter(me._wcurpath)
+      }
+      
       if (me._wcurpath.match(filter)) {
         return true;
       }


### PR DESCRIPTION
Hi, what do you think about allowing functions on 'option.filters'?